### PR TITLE
Problem: SpiClient re-instantiation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ msrv = "1.65"
 pgx = ">=0.6.0-alpha.1"
 
 [patch.crates-io]
-pgx = { git = "https://github.com/tcdi/pgx", rev = "7430ce1" }
+pgx = { git = "https://github.com/yrashk/pgx", rev = "a0e27e46" }
 
 [features]
 default = []

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,8 +23,8 @@ pgx-contrib-spiext = { path = ".." }
 pgx-tests = ">=0.6.0-alpha.1"
 
 [patch.crates-io]
-pgx = { git = "https://github.com/tcdi/pgx", rev = "7430ce1" }
-pgx-tests = { git = "https://github.com/tcdi/pgx", rev = "7430ce1" }
+pgx = { git = "https://github.com/yrashk/pgx", rev = "a0e27e46" }
+pgx-tests = { git = "https://github.com/yrashk/pgx", rev = "a0e27e46" }
 
 [profile.dev]
 panic = "unwind"


### PR DESCRIPTION
It's not a very good practice.

Solution: use reference-counted SpiClient and its singleton

The use of singleton ensures that when we're consuming a client into a transaction, there are no outstanding clones, so it's a safe bet that nothing else will be going on (barring "unsafe" simultaneous use of distinct SpiClients)

This change relies on https://github.com/tcdi/pgx/pull/883
